### PR TITLE
fix(docs): build workspace libs before the Nuxt build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,8 +10,9 @@
     "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "dev": "nuxt dev",
-    "build": "nuxt build",
-    "generate": "nuxt generate",
+    "build:deps": "pnpm --filter @robonen/stdlib --filter @robonen/platform --filter @robonen/fetch --filter @robonen/encoding --filter @robonen/crdt --filter @robonen/vue --filter @robonen/primitives --filter @robonen/writekit build",
+    "build": "pnpm run build:deps && nuxt build",
+    "generate": "pnpm run build:deps && nuxt generate",
     "preview": "nuxt preview",
     "extract": "jiti ./modules/extractor/extract.ts"
   },


### PR DESCRIPTION
The SFC type resolver resolves `@robonen/*` package imports (e.g. PrimitiveProps, used in `defineProps<X extends PrimitiveProps>()`) via the package `exports` → `dist/*.d.ts`, independently of the Vite source-alias. On a fresh checkout (CI / Vercel) those dist files don't exist yet, so the compiler throws 'Failed to resolve extends base type'. `build`/`generate` now run `build:deps` first.